### PR TITLE
Renamed nim-assimp to nim_assimp

### DIFF
--- a/nim_assimp.babel
+++ b/nim_assimp.babel
@@ -1,5 +1,5 @@
 [Package]
-name = "nim-assimp"
+name = "nim_assimp"
 version = "0.1.1"
 author = "fowl"
 description = "Assorted wrappers and reusable libraries."


### PR DESCRIPTION
This was done because the nimble install threw out errors:  " nim-assimp is an invalid package name: cannot contain '-' "